### PR TITLE
Expose the expiration time of the auth token

### DIFF
--- a/lib/omniauth/strategies/ebay.rb
+++ b/lib/omniauth/strategies/ebay.rb
@@ -28,7 +28,7 @@ module OmniAuth
       info do
         {
             :ebay_id => raw_info['UserID'],
-            :ebay_token => @auth_token,
+            :ebay_token => @auth_token.value,
             :email => raw_info['Email'],
             :full_name => raw_info["RegistrationAddress"] && raw_info["RegistrationAddress"]["Name"],
             :country => raw_info["RegistrationAddress"] && raw_info["RegistrationAddress"]["Country"],
@@ -39,7 +39,9 @@ module OmniAuth
 
       credentials do
         {
-          :token => @auth_token,
+          :token => @auth_token.value,
+          :expires => @auth_token.expires?,
+          :expires_at => @auth_token.expires_at,
         }
       end
 
@@ -65,7 +67,7 @@ module OmniAuth
       #6: Request the user info from eBay
       def callback_phase
         @auth_token = get_auth_token(request.params["username"], request.params["sid"])
-        @user_info = get_user_info(request.params["username"], @auth_token)
+        @user_info = get_user_info(request.params["username"], @auth_token.value)
         super
       rescue => ex
         fail!("Failed to retrieve user info from ebay", ex)

--- a/spec/omniauth/strategies/ebay_spec.rb
+++ b/spec/omniauth/strategies/ebay_spec.rb
@@ -52,6 +52,8 @@ describe OmniAuth::Strategies::Ebay do
 
         auth_hash["credentials"].should_not be_nil
         auth_hash["credentials"]["token"].should == "fake_auth_token"
+        auth_hash["credentials"]["expires"].should == true
+        auth_hash["credentials"]["expires_at"].should == 1381221410
 
         auth_hash["extra"].should_not be_nil
         # returns entire response from GetUser


### PR DESCRIPTION
eBay authentication tokens expire after 18 months.
The expiration time is provided when the token is first retrieved.

Return the expiration information in the `credentials` hash,
as specified in the OmniAuth docs:
https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema

`expires_at` is returned as an integer (epoch time) to be
consistent with omniauth-oauth2.
